### PR TITLE
add CompletionRequirementDto for position completion gaps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export {
   type AnalyticsAccessDto,
   type AccountsVisitorsDto,
   type ExtendedPositionDto,
+  type CompletionRequirementDto,
   type GroupedPositionDto,
   type ExtendedUserDetailsDto,
   type ProfileViewsResponseDto,

--- a/src/user.dto.ts
+++ b/src/user.dto.ts
@@ -242,9 +242,26 @@ export interface AccountsVisitorsDto {
   updatedAt: Date;
 }
 
+/**
+ * One requirement counting toward a position reaching 100% completion.
+ *
+ * Completion is all-or-nothing: a job posting captures the same field set as a position and
+ * matching compares them field by field, so anything short of 100% cannot be matched. The
+ * UI therefore needs to name the outstanding fields, not just show a percentage.
+ */
+export interface CompletionRequirementDto {
+  /** Stable identifier, e.g. `details.averageDealSize`. Safe to key or deep-link on. */
+  key: string;
+  /** User-facing label, phrased as the thing being asked for. */
+  label: string;
+  filled: boolean;
+}
+
 export interface ExtendedPositionDto extends PositionDto {
   isCompleted?: boolean;
   completionPercentage?: number;
+  /** Requirements still outstanding for this position. Empty when `isCompleted` is true. */
+  missingFields?: CompletionRequirementDto[];
   verifyRequest: VerifyPositionDto[]; // Updated verify requests with enriched user details
 }
 


### PR DESCRIPTION
Adds `CompletionRequirementDto` — the shape describing one requirement counting toward a position reaching 100% completion (`key`, `label`, `filled`) — and an optional `missingFields` on `ExtendedPositionDto`.

Completion is all-or-nothing: a job posting captures the same field set as a position and matching compares them field by field, so anything short of 100% cannot be matched rather than merely looking unfinished. Until now the API returned only `completionPercentage`, so the UI could show "85%" but not say which fields were outstanding — leaving users to hunt through roughly 27 inputs for the gap.

Types only, no behaviour. Consumed by:

- **backend** — [Trackrec/backend#631](https://github.com/Trackrec/backend/pull/631) (needs this merged first, then its submodule pointer retargeted to `main`)
- **frontend** — to follow, for rendering the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)